### PR TITLE
Fix large expense value truncation in edit mode

### DIFF
--- a/app/src/main/res/layout/activity_expense.xml
+++ b/app/src/main/res/layout/activity_expense.xml
@@ -54,7 +54,7 @@
                     android:layout_weight="9.5"
                     android:hint="@string/hint_value"
                     android:inputType="number"
-                    android:maxLength="16"
+                    android:maxLength="24"
                     android:textColor="@color/red"
                     android:textColorHint="@color/red"
                     android:textSize="30sp" />

--- a/app/src/test/java/luankevinferreira/expenses/util/CurrencyTextWatcherTest.java
+++ b/app/src/test/java/luankevinferreira/expenses/util/CurrencyTextWatcherTest.java
@@ -87,6 +87,18 @@ public class CurrencyTextWatcherTest {
     }
 
     @Test
+    public void testShouldFormatNineDigitIntegerPartBrazilian() {
+        // Prepare - user typed digits for 123.456.789,01
+        String input = "12345678901";
+
+        // Action
+        String result = simulateFormat(input, LOCALE_PT_BR);
+
+        // Verify
+        assertEquals("R$ 123.456.789,01", result);
+    }
+
+    @Test
     public void testShouldFormatEmptyInputBrazilian() {
         // Prepare
         String input = "";

--- a/app/src/test/java/luankevinferreira/expenses/util/CurrencyUtilsTest.java
+++ b/app/src/test/java/luankevinferreira/expenses/util/CurrencyUtilsTest.java
@@ -86,6 +86,18 @@ public class CurrencyUtilsTest {
         assertEquals("R$ 99.999,99", result);
     }
 
+    @Test
+    public void testShouldFormatNineDigitIntegerPartForBrazilianLocale() {
+        // Prepare
+        double value = 123456789.01;
+
+        // Action
+        String result = CurrencyUtils.formatCurrency(value, LOCALE_PT_BR);
+
+        // Verify
+        assertEquals("R$ 123.456.789,01", result);
+    }
+
     // --- formatCents(long, Locale) ---
 
     @Test
@@ -232,6 +244,20 @@ public class CurrencyUtilsTest {
 
         // Verify
         assertEquals(1, result);
+    }
+
+    @Test
+    public void testShouldConvertAndRoundTripLargeValueWithoutChangingCents() {
+        // Prepare
+        double value = 123456789.01;
+
+        // Action
+        long cents = CurrencyUtils.doubleToCents(value);
+        double roundTrip = CurrencyUtils.centsToDouble(cents);
+
+        // Verify
+        assertEquals(12345678901L, cents);
+        assertEquals(value, roundTrip, DELTA);
     }
 
     // --- parseCurrency(String, Locale) ---


### PR DESCRIPTION
Increase the expense value input limit to keep formatted 9+ digit amounts intact when reopening an expense for editing, and add regression tests for large-value currency formatting and round-trip conversion.